### PR TITLE
removed 'Order' from title

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -80,7 +80,7 @@ var View = Cycle.createView(Model =>
     ({
       vtree$: Model.get('model$').map(model =>
         Cycle.h('div', [
-          Cycle.h('h1', 'TODO: Order Minimum Viable Pizza'),
+          Cycle.h('h1', 'TODO: Minimum Viable Pizza'),
           renderSave(model.gathering),
           renderEaters(model.gathering),
           renderMenuSelection(model.menus, model.gathering),


### PR DESCRIPTION
I think having the title read _TODO: Minimum Viable Pizza_ fits with the theme, the url, the pun, and just sounds better.

Looking forward to a heated discussion as I build an API scraper....
